### PR TITLE
Remove unused imports and simplify installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,85 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+venv/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/build/
+docs/source/generated/
+
+# pytest
+.pytest_cache/
+
+# PyBuilder
+target/
+
+# Editor files
+#mac
+.DS_Store
+*~
+
+#vim
+*.swp
+*.swo
+
+#pycharm
+.idea/
+
+#VSCode
+.vscode/
+
+#Ipython Notebook
+.ipynb_checkpoints
+
+
+_as_gen

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ target/
 
 
 _as_gen
+
+model.bin

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Specifically, SARfish breaks down the input SAR geotiff file into 800x800 shards
 
 ### Requirements
 
-- **Python 3.9** 
-- **conda**: The installation script that installs the dependencies needs to use both conda and pip to fetch the required dependencies, so please use conda and create a new conda virtual environment.
+- **Python 3.9**+
+- **conda**: Due to the geo-spatial libraries required it is easiest to install the dependencies with conda
 
 ### Installing Package Dependencies
 
 1. Create the conda environment. This will install all necessary package dependencies too.
 
 ```shell
-conda env create -f environment.yml
+conda create -n sarfish python gdal numpy pandas shapely matplotlib pytorch torchvision rasterio ipython tqdm geopandas
 ```
 
 2. Activate the conda environment created.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Specifically, SARfish breaks down the input SAR geotiff file into 800x800 shards
 1. Create the conda environment. This will install all necessary package dependencies too.
 
 ```shell
-conda create -n sarfish python gdal numpy pandas shapely matplotlib pytorch torchvision rasterio ipython tqdm geopandas
+conda create -n sarfish -c conda-forge python gdal numpy pandas shapely matplotlib pytorch torchvision rasterio ipython tqdm geopandas
 ```
 
 2. Activate the conda environment created.

--- a/SARfish.py
+++ b/SARfish.py
@@ -20,7 +20,7 @@ import rasterio
 
 import pickle
 import sys
-import gdal
+import osgeo.gdal as gdal
 import geopandas as gpd
 from osgeo import osr
 from shapely.geometry import Point

--- a/SARfish.py
+++ b/SARfish.py
@@ -1,42 +1,29 @@
-import numpy 
-import pandas as pd 
-import random
+import numpy
+import pandas as pd
 from PIL import Image
-from matplotlib import pyplot as plt
-import xml.etree.ElementTree as ET
 
-import torch 
+import torch
 import torchvision
-from torchvision import transforms, datasets
+from torchvision import transforms
 
 import os
 import shutil
 import numpy as np
-import matplotlib.pyplot as plt
-from torchvision.utils import draw_bounding_boxes
-from torchvision.io import read_image
 
-import torchvision.transforms.functional as F
 from torchvision.models.detection.faster_rcnn import FastRCNNPredictor
 from shapely import geometry
-from rasterio.mask import mask 
+from rasterio.mask import mask
 import glob
 from tqdm import tqdm
 import rasterio
-import folium
 
 
 import pickle
 import sys
 import gdal
 import geopandas as gpd
-import matplotlib
-import matplotlib.pyplot as plt
-from numba import jit
 from osgeo import osr
-import PIL
-from PIL import Image, TiffImagePlugin
-from shapely.geometry import Point, Polygon, box
+from shapely.geometry import Point
 from geopandas import GeoDataFrame
 
 
@@ -56,12 +43,12 @@ def prepare_image(image_path):
   im.save(jpg_path)
   img = Image.open(jpg_path).convert("RGB")
   img_transforms = transforms.Compose([
-                                      transforms.Resize((800,800)), 
+                                      transforms.Resize((800,800)),
                                       transforms.ToTensor(),
                                       transforms.Normalize(mean=0.5, std=0.2)
                                       ])
   img = img_transforms(img)
-  return img 
+  return img
 
 # def get_new_image_detections(image_path, threashold):
 #   img = prepare_image(image_path)
@@ -209,28 +196,28 @@ def pixel2coord(img_path, x, y):
     new_cs.ImportFromWkt(wgs84_wkt)
 
     # create a transform object to convert between coordinate systems
-    transform = osr.CoordinateTransformation(old_cs,new_cs) 
-    
+    transform = osr.CoordinateTransformation(old_cs,new_cs)
+
     gt = ds.GetGeoTransform()
 
-    # GDAL affine transform parameters, According to gdal documentation xoff/yoff are image left corner, a/e are pixel wight/height and b/d is rotation and is zero if image is north up. 
+    # GDAL affine transform parameters, According to gdal documentation xoff/yoff are image left corner, a/e are pixel wight/height and b/d is rotation and is zero if image is north up.
     xoff, a, b, yoff, d, e = gt
 
     xp = a * x + b * y + xoff
     yp = d * x + e * y + yoff
 
-    lat_lon = transform.TransformPoint(xp, yp) 
+    lat_lon = transform.TransformPoint(xp, yp)
 
     xp = lat_lon[0]
     yp = lat_lon[1]
-    
+
     return (xp, yp)
 
 
 def find_img_coordinates(img_array, image_filename):
     img_coordinates = np.zeros((img_array.shape[0], img_array.shape[1], 2)).tolist()
     for row in range(0, img_array.shape[0]):
-        for col in range(0, img_array.shape[1]): 
+        for col in range(0, img_array.shape[1]):
             img_coordinates[row][col] = Point(pixel2coord(img_path=image_filename, x=col, y=row))
     return img_coordinates
 
@@ -375,6 +362,3 @@ model_ft.eval()
 
 get_geojson_detections(tiff_filepath, shard_dir, output_geojson_filepath)
 shutil.rmtree(shard_dir)
-
-
-

--- a/SARfish.py
+++ b/SARfish.py
@@ -353,7 +353,7 @@ tiff_filepath = rootdir+"/"+tiff_filename
 output_geojson_filepath = rootdir+"/" + output_geojson_filename
 
 
-os.mkdir(shard_dir)
+os.makedirs(shard_dir, exist_ok=True)
 
 num_classes = 2
 model_ft = get_instance_segmentation_model(num_classes)


### PR DESCRIPTION
The enviroment.yml file is pinned to OSX (so it does not run on linux or windows) and is inconsistent on OSX arm.

To make the conda installation simpler I also updated the gdal import to the "new style" and removed a bunch of unused imports (but at least `numba` will install easily on top if that is really needed).